### PR TITLE
fix(socketio): fix for socket handshake property change

### DIFF
--- a/app/templates/server/config/socketio(socketio).js
+++ b/app/templates/server/config/socketio(socketio).js
@@ -38,8 +38,8 @@ module.exports = function (socketio) {
   // }));
 
   socketio.on('connection', function (socket) {
-    socket.address = socket.handshake.address !== null ?
-            socket.handshake.address.address + ':' + socket.handshake.address.port :
+    socket.address = (socket.handshake.address !== null && socket.request.connection.remotePort) ?
+            socket.handshake.address.address + ':' + socket.request.connection.remotePort :
             process.env.DOMAIN;
 
     socket.connectedAt = new Date();


### PR DESCRIPTION
The ```socket.handshake.address``` property changed right in socket.io (https://github.com/Automattic/socket.io/commit/54726105cbab5acba3176fbc11b7af06508d2d52) right around the time it was changed here (https://github.com/DaftMonk/generator-angular-fullstack/pull/369). Looks like it just made it into the 1.1.0 release a couple of weeks ago.