### PR TITLE
fix(app): missing event.preventDefault

### DIFF
--- a/app/templates/client/app/app(js).js
+++ b/app/templates/client/app/app(js).js
@@ -48,6 +48,7 @@ angular.module('<%= scriptAppName %>', [<%= angularModules %>])
     $rootScope.$on(<% if(filters.ngroute) { %>'$routeChangeStart'<% } %><% if(filters.uirouter) { %>'$stateChangeStart'<% } %>, function (event, next) {
       Auth.isLoggedInAsync(function(loggedIn) {
         if (next.authenticate && !loggedIn) {
+          event.preventDefault();
           $location.path('/login');
         }
       });


### PR DESCRIPTION
This PR adds event.preventDefault() to the $on('$stateChangeStart) Auth intercept because it fixed an intermittent bug in my code.

I made the following change in my code:

    // Before:
    if (next.authenticate && !loggedIn) {
        $location.path('/login');
    }

    // After
    if (!loggedIn && next.name !== 'login') {
          event.preventDefault();
          $state.go('login');
    }

Before adding event.preventDefault(), the state intercept would intermittently fail to redirect the user to the login view. Specifically when clicking \<a href=""> links. Adding event.preventDefault() fixed the problem.