### PR TITLE
refactor(app): Remove an extra function parameter

### DIFF
--- a/app/templates/server/auth(auth)/auth.service.js
+++ b/app/templates/server/auth(auth)/auth.service.js
@@ -86,7 +86,7 @@ function setTokenCookie(req, res) {
       message: 'Something went wrong, please try again.'
     });
   }
-  var token = signToken(req.user._id, req.user.role);
+  var token = signToken(req.user._id);
   res.cookie('token', JSON.stringify(token));
   res.redirect('/');
 }


### PR DESCRIPTION
Change the parameters passed into the signToken function. This change is
trivial and tidies up the code.

No breaking change. Fixes issue #382