### PR TITLE
feat(server:auth): allow cookie to contain authentication token

### DIFF
--- a/app/templates/server/auth(auth)/auth.service.js
+++ b/app/templates/server/auth(auth)/auth.service.js
@@ -17,9 +17,16 @@ function isAuthenticated() {
   return compose()
     // Validate jwt
     .use(function(req, res, next) {
-      // allow access_token to be passed through query parameter as well
-      if(req.query && req.query.hasOwnProperty('access_token')) {
-        req.headers.authorization = 'Bearer ' + req.query.access_token;
+      if (!req.headers.authorization) {
+        // allow access_token to be passed through query parameter or cookie as well
+        if(req.query && req.query.hasOwnProperty('access_token')) {
+          req.headers.authorization = 'Bearer ' + req.query.access_token;
+        } else if (req.cookies.token) {
+          console.log("found" + req.cookies.token);
+          try {
+            req.headers.authorization = 'Bearer ' + JSON.parse(req.cookies.token);
+          } finally {}
+        }
       }
       validateJwt(req, res, next);
     })


### PR DESCRIPTION
This enables users to access the API from the browser without having to set headers.

If the setTokenCookie is added for all authentication strategies (why isn't it?), it also makes API tests simpler, since they can just use a request agent with a cookie store (See #494).

Note the wrapping `if` that only does this when there's no `Authorization` header.