### PR TITLE
refactor(app): Remove an extra function parameter

### DIFF
--- a/app/templates/server/auth(auth)/local/index.js
+++ b/app/templates/server/auth(auth)/local/index.js
@@ -18,7 +18,7 @@ router.post('/', function(req, res, next) {
       });
     }
 
-    var token = auth.signToken(user._id, user.role);
+    var token = auth.signToken(user._id);
     res.json({ token: token });
   })(req, res, next)
 });


### PR DESCRIPTION
Remove the last parameter from signToken cause it only uses one ('id')