### PR TITLE
docs: changing from mongohq to mongolab

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,7 +261,7 @@ To work with your new heroku app using the command line, you will need to run an
 
 If you're using mongoDB you will need to add a database to your app:
 
-    heroku addons:add mongohq
+    heroku addons:add mongolab
 
 Your app should now be live. To view it run `heroku open`.
 


### PR DESCRIPTION
MongoHQ has removed their free plan from Heroku. Adding MongoHQ with the current statement results in a monthly charge. MongoLab has a free sandbox plan and adding it is free.