### PR TITLE
fixing potential btn-google-plus name collision

### DIFF
--- a/app/templates/client/app/account(auth)/login/login(css).css
+++ b/app/templates/client/app/account(auth)/login/login(css).css
@@ -10,7 +10,7 @@
   border-color: #0271bf;
 }
 <% } if (filters.googleAuth) { %>
-.btn-google-plus {
+.google-plus-btn {
   color: #fff;
   background-color: #dd4b39;
   border-color: #c53727;

--- a/app/templates/client/app/account(auth)/login/login(html).html
+++ b/app/templates/client/app/account(auth)/login/login(html).html
@@ -47,7 +47,7 @@
           <a class="btn btn-facebook" href="" ng-click="loginOauth('facebook')">
             <i class="fa fa-facebook"></i> Connect with Facebook
           </a><% } %><% if(filters.googleAuth) {%>
-          <a class="btn btn-google-plus" href="" ng-click="loginOauth('google')">
+          <a class="btn google-plus-btn" href="" ng-click="loginOauth('google')">
             <i class="fa fa-google-plus"></i> Connect with Google+
           </a><% } %><% if(filters.twitterAuth) {%>
           <a class="btn btn-twitter" href="" ng-click="loginOauth('twitter')">

--- a/app/templates/client/app/account(auth)/login/login(jade).jade
+++ b/app/templates/client/app/account(auth)/login/login(jade).jade
@@ -44,7 +44,7 @@ div(ng-include='"components/navbar/navbar.html"')
             i.fa.fa-facebook
             |  Connect with Facebook
           = ' '<% } %><% if(filters.googleAuth) {%>
-          a.btn.btn-google-plus(href='', ng-click='loginOauth("google")')
+          a.btn.google-plus-btn(href='', ng-click='loginOauth("google")')
             i.fa.fa-google-plus
             |  Connect with Google+
           = ' '<% } %><% if(filters.twitterAuth) {%>

--- a/app/templates/client/app/account(auth)/login/login(less).less
+++ b/app/templates/client/app/account(auth)/login/login(less).less
@@ -22,7 +22,7 @@
 .btn-twitter {
   .button-variant(@btnText; @btnTwitterBackground; @btnTwitterBackgroundHighlight);
 }<% } if (filters.googleAuth) { %>
-.btn-google-plus {
+.google-plus-btn {
   .button-variant(@btnText; @btnGooglePlusBackground; @btnGooglePlusBackgroundHighlight);
 }<% } %>
 .btn-github {

--- a/app/templates/client/app/account(auth)/login/login(sass).scss
+++ b/app/templates/client/app/account(auth)/login/login(sass).scss
@@ -22,7 +22,7 @@ $btnGithubBackgroundHighlight:      #ccc;
 .btn-twitter {
   @include button-variant($btnText, $btnTwitterBackground, $btnTwitterBackgroundHighlight);
 }<% } if (filters.googleAuth) { %>
-.btn-google-plus {
+.google-plus-btn {
   @include button-variant($btnText, $btnGooglePlusBackground, $btnGooglePlusBackgroundHighlight);
 }<% } %>
 .btn-github {

--- a/app/templates/client/app/account(auth)/login/login(stylus).styl
+++ b/app/templates/client/app/account(auth)/login/login(stylus).styl
@@ -11,7 +11,7 @@
     background-color: #2daddc;
     border-color: #0271bf;
 <% } if (filters.googleAuth) { %>
-.btn-google-plus
+.google-plus-btn
     color: #fff;
     background-color: #dd4b39;
     border-color: #c53727;

--- a/app/templates/client/app/account(auth)/signup/signup(html).html
+++ b/app/templates/client/app/account(auth)/signup/signup(html).html
@@ -68,7 +68,7 @@
           <a class="btn btn-facebook" href="" ng-click="loginOauth('facebook')">
             <i class="fa fa-facebook"></i> Connect with Facebook
           </a><% } %><% if(filters.googleAuth) {%>
-          <a class="btn btn-google-plus" href="" ng-click="loginOauth('google')">
+          <a class="btn google-plus-btn" href="" ng-click="loginOauth('google')">
             <i class="fa fa-google-plus"></i> Connect with Google+
           </a><% } %><% if(filters.twitterAuth) {%>
           <a class="btn btn-twitter" href="" ng-click="loginOauth('twitter')">

--- a/app/templates/client/app/account(auth)/signup/signup(jade).jade
+++ b/app/templates/client/app/account(auth)/signup/signup(jade).jade
@@ -47,7 +47,7 @@ div(ng-include='"components/navbar/navbar.html"')
             i.fa.fa-facebook
             |  Connect with Facebook
           = ' '<% } %><% if(filters.googleAuth) {%>
-          a.btn.btn-google-plus(href='', ng-click='loginOauth("google")')
+          a.btn.google-plus-btn(href='', ng-click='loginOauth("google")')
             i.fa.fa-google-plus
             |  Connect with Google+
           = ' '<% } %><% if(filters.twitterAuth) {%>


### PR DESCRIPTION
The default project when generated with google authentication would not display the google button on the login/signup pages. I experienced this issue with both sass and css versions. I am using firefox 35.0.1 on linux.

Steps to reproduce issue:

1. generate project using google+ oauth. 
2. go to /login or /signin. the google+ button is nowhere to be found.

Proposed fix:

Changing the classname fixed the issue for me. I propose changing it from btn-google-plus to google-plus-btn.

I can only assume that bootstrap has a class by the same name that is overriding the styles or something.

Can anyone else reproduce this?
