### PR TITLE
feat(app): Use grunt-keepalive

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -717,13 +717,9 @@ module.exports = function (grunt) {
     }, 1500);
   });
 
-  grunt.registerTask('express-keepalive', 'Keep grunt running', function() {
-    this.async();
-  });
-
   grunt.registerTask('serve', function (target) {
     if (target === 'dist') {
-      return grunt.task.run(['build', 'env:all', 'env:prod', 'express:prod', 'wait', 'open', 'express-keepalive']);
+      return grunt.task.run(['build', 'env:all', 'env:prod', 'express:prod', 'wait', 'open', 'keepalive']);
     }
 
     if (target === 'debug') {

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -60,6 +60,7 @@
     "grunt-protractor-runner": "^1.1.0",
     "grunt-injector": "~0.5.4",
     "grunt-karma": "~0.8.2",
+    "grunt-keepalive": "~0.0.1",
     "grunt-build-control": "DaftMonk/grunt-build-control",
     "grunt-mocha-test": "~0.10.2",<% if(filters.sass) { %>
     "grunt-contrib-sass": "^0.7.3",<% } %><% if(filters.stylus) { %>


### PR DESCRIPTION
Instead of configuring a task to keep the express alive,
Use an [existing module](https://www.npmjs.com/package/grunt-keepalive).

FD: I wrote the module :grin: 