### PR TITLE
feat(app): add mongodb error handling to quit app if unable to connect with

### DIFF
--- a/app/templates/server/app.js
+++ b/app/templates/server/app.js
@@ -13,7 +13,11 @@ var config = require('./config/environment');
 <% if (filters.mongoose) { %>
 // Connect to database
 mongoose.connect(config.mongo.uri, config.mongo.options);
-
+mongoose.connection.on('error', function(err) {
+	console.error('MongoDB connection error: ' + err);
+	process.exit(-1);
+	}
+);
 // Populate DB with sample data
 if(config.seedDB) { require('./config/seed'); }
 


### PR DESCRIPTION
feat(app): add mongodb error handling to quit app if unable to connect with mongodb server for some
reason
    
when the app will be started with grunt serve, if configured to run with mongodb and the service
will not be available, then the app will initialize anyway but mostly this isnt desired and no
handling or debug information of why the app has no connection to a mongodb server will be
provided