### PR TITLE
fix(app:seed): adding empty where clause for Sequelize destroy calls

### DIFF
--- a/app/templates/server/config/seed(models).js
+++ b/app/templates/server/config/seed(models).js
@@ -15,7 +15,7 @@ var Thing = sqldb.Thing;
 <% if (filters.mongooseModels) { %>Thing.find({}).removeAsync()<% }
    if (filters.sequelizeModels) { %>Thing.sync()
   .then(function() {
-    return Thing.destroy();
+    return Thing.destroy({where: {}});
   })<% } %>
   .then(function() {
     <% if (filters.mongooseModels) { %>Thing.create({<% }
@@ -53,7 +53,7 @@ var Thing = sqldb.Thing;
 <% if (filters.mongooseModels) { %>User.find({}).removeAsync()<% }
    if (filters.sequelizeModels) { %>User.sync()
   .then(function() {
-    User.destroy();
+    User.destroy({where: {}});
   })<% } %>
   .then(function() {
     <% if (filters.mongooseModels) { %>User.createAsync({<% }


### PR DESCRIPTION
Sequelize destroy cannot be called without a where clause
 (https://github.com/sequelize/sequelize/issues/3131),
 this causes the following error message: `Missing where or
 truncate attribute in the options parameter passed to destroy.`