### PR TITLE
fix(server): prevent require undefined module

### DIFF
--- a/app/templates/server/config/environment/index.js
+++ b/app/templates/server/config/environment/index.js
@@ -64,4 +64,4 @@ var all = {
 // ==============================================
 module.exports = _.merge(
   all,
-  require('./' + process.env.NODE_ENV + '.js') || {});
+  all.env ? require('./' + all.env + '.js') : {});


### PR DESCRIPTION
the previous code would actually require(./undefined.js) if the NODE_ENV is not defined