### PR TITLE
correction to generate endpoint with 'endpointDirectory'

### DIFF
--- a/endpoint/index.js
+++ b/endpoint/index.js
@@ -70,7 +70,7 @@ Generator.prototype.registerEndpoint = function registerEndpoint() {
 };
 
 Generator.prototype.createFiles = function createFiles() {
-  var dest = this.config.get('endpointDirectory') || 'server/api/' + this.name;
+  var dest = this.config.get('endpointDirectory') + this.name || 'server/api/' + this.name;
   this.sourceRoot(path.join(__dirname, './templates'));
   ngUtil.processDirectory(this, '.', dest);
 };


### PR DESCRIPTION
Hello Friend,

First congratulations for the great job, I am using the generator for two projects.

I use 3 project and had to make a folder changes.

I configured in **.yo-rc.json** the **"endpointDirectory"** but when creating the template was generated in the path of the root "routesBase".

So I packed the:

**Generator.prototype.createFiles;**

The **dest** when setted the "endpointDirectory" was without **this.name**;

I hope it helps!

regards