### PR TITLE
fix(travis): remove node v0.11 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - '0.10'
-  - '0.11'
   - '0.12'
 env:
   global:


### PR DESCRIPTION
Testing on node `v0.11` isn't need now since `v0.12` is out.