### PR TITLE
Fix Grunfile.js ngAnnotate task src

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -349,7 +349,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: '.tmp/concat',
-          src: '*/**.js',
+          src: '**/*.js',
           dest: '.tmp/concat'
         }]
       }


### PR DESCRIPTION
Fix Grunfile.js ngAnnotate task src from `*/**.js` to `**/*.js`