### PR TITLE
Update passport auth api

### DIFF
--- a/app/templates/server/auth(auth)/facebook(facebookAuth)/passport.js
+++ b/app/templates/server/auth(auth)/facebook(facebookAuth)/passport.js
@@ -5,7 +5,11 @@ exports.setup = function(User, config) {
   passport.use(new FacebookStrategy({
     clientID: config.facebook.clientID,
     clientSecret: config.facebook.clientSecret,
-    callbackURL: config.facebook.callbackURL
+    callbackURL: config.facebook.callbackURL,
+    profileFields: [
+      'displayName',
+      'emails'
+    ]
   },
   function(accessToken, refreshToken, profile, done) {
     <% if (filters.mongooseModels) { %>User.findOneAsync({<% }
@@ -19,7 +23,6 @@ exports.setup = function(User, config) {
             name: profile.displayName,
             email: profile.emails[0].value,
             role: 'user',
-            username: profile.username,
             provider: 'facebook',
             facebook: profile._json
           });

--- a/app/templates/server/auth(auth)/google(googleAuth)/index.js
+++ b/app/templates/server/auth(auth)/google(googleAuth)/index.js
@@ -10,8 +10,8 @@ router
   .get('/', passport.authenticate('google', {
     failureRedirect: '/signup',
     scope: [
-      'https://www.googleapis.com/auth/userinfo.profile',
-      'https://www.googleapis.com/auth/userinfo.email'
+      'profile',
+      'email'
     ],
     session: false
   }))

--- a/app/templates/server/auth(auth)/google(googleAuth)/passport.js
+++ b/app/templates/server/auth(auth)/google(googleAuth)/passport.js
@@ -19,7 +19,7 @@ exports.setup = function(User, config) {
             name: profile.displayName,
             email: profile.emails[0].value,
             role: 'user',
-            username: profile.username,
+            username: profile.emails[0].value.split('@')[0],
             provider: 'google',
             google: profile._json
           });


### PR DESCRIPTION
There have been some API changes.

As of July 8th Facebook introduced v2.4 of their API. The default request only responds with id and name now.
If you create a Facebook app after July 8th you are forced to use v2.4 so this breaks the app (even though passport is currently defaulted to use v2.2, Facebook forces you).

Google has deprecated the use of `https://www.googleapis.com/auth/userinfo.profile` and `https://www.googleapis.com/auth/userinfo.email`. You should use `profile` and `email`.