### PR TITLE
chore(dependencies): remove `peerDependencies` and update docs to reflect

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "chalk": "~0.4.0",
     "generator-ng-component": "~0.0.4"
   },
-  "peerDependencies": {
-    "yo": ">=1.2.0"
-  },
   "devDependencies": {
     "chai": "^1.9.1",
     "fs-extra": "^0.9.1",

--- a/readme.md
+++ b/readme.md
@@ -11,9 +11,9 @@ Source code: https://github.com/DaftMonk/fullstack-demo
 
 ## Usage
 
-Install `generator-angular-fullstack`:
+Install `yo`, `grunt-cli`, `bower`, and `generator-angular-fullstack`:
 ```
-npm install -g generator-angular-fullstack
+npm install -g yo grunt-cli bower generator-angular-fullstack
 ```
 
 Make a new directory, and `cd` into it:


### PR DESCRIPTION
> npm3 will no longer install peerDependencies, which is a very good change, but will impact how we currently use it