### PR TITLE
docs(gen): update readme.md to reflect new heroku commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -263,7 +263,7 @@ To work with your new heroku app using the command line, you will need to run an
 
 If you're using mongoDB you will need to add a database to your app:
 
-    heroku addons:add mongolab
+    heroku addons:create mongolab
 
 Your app should now be live. To view it run `heroku open`.
 


### PR DESCRIPTION
Heroku add-ons commands have changed. The old addons:add command is now deprecated. See here: https://devcenter.heroku.com/articles/managing-add-ons