### PR TITLE
fix(app:test): include `client/components` in babel preprocessing

### DIFF
--- a/app/templates/karma.conf.js
+++ b/app/templates/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
     preprocessors: {
       '**/*.jade': 'ng-jade2js',
       '**/*.html': 'html2js',<% if(filters.babel) { %>
-      'client/app/**/*.js': 'babel',<% } %>
+      'client/{app,components}/**/*.js': 'babel',<% } %>
       '**/*.coffee': 'coffee',
     },
 


### PR DESCRIPTION
closes DaftMonk/generator-angular-fullstack#1081