### PR TITLE
Specify field name like email to Facebook Oauth settings(profileFields)

### DIFF
--- a/app/templates/server/auth(auth)/facebook(facebookAuth)/passport.js
+++ b/app/templates/server/auth(auth)/facebook(facebookAuth)/passport.js
@@ -5,7 +5,8 @@ exports.setup = function (User, config) {
   passport.use(new FacebookStrategy({
       clientID: config.facebook.clientID,
       clientSecret: config.facebook.clientSecret,
-      callbackURL: config.facebook.callbackURL
+      callbackURL: config.facebook.callbackURL,
+      profileFields: ['displayName', 'name', 'profileUrl', 'id', 'email',  'photos', 'gender', 'locale', 'timezone', 'updated_time', 'verified']
     },
     function(accessToken, refreshToken, profile, done) {
       User.findOne({


### PR DESCRIPTION
On Facebook Graph API v2.4, only "id" or "name" fields is retrived by default,
So, Facebook login caused error message:
===============================================
/app/server/auth/facebook/passport.js:21
                                 ^
            email: profile.emails[0].value,
TypeError: Cannot read property '0' of undefined
===============================================