### PR TITLE
app.coffee is missing preventDefault(); auth.service changePassword() chore

### DIFF
--- a/app/templates/client/app/app(coffee).coffee
+++ b/app/templates/client/app/app(coffee).coffee
@@ -36,5 +36,6 @@ angular.module '<%= scriptAppName %>', [<%= angularModules %>]
   # Redirect to login if route requires auth and you're not logged in
   $rootScope.$on <% if (filters.ngroute) { %>'$routeChangeStart'<% } %><% if (filters.uirouter) { %>'$stateChangeStart'<% } %>, (event, next) ->
     Auth.isLoggedIn (loggedIn) ->
+      event.preventDefault()
       <% if (filters.ngroute) { %>$location.path '/login'<% } %><% if (filters.uirouter) { %>$state.go 'login'<% } %> if next.authenticate and not loggedIn
 <% } %>

--- a/app/templates/client/components/auth(auth)/auth.service(coffee).coffee
+++ b/app/templates/client/components/auth(auth)/auth.service(coffee).coffee
@@ -73,8 +73,8 @@ angular.module '<%= scriptAppName %>'
       oldPassword: oldPassword
       newPassword: newPassword
 
-    , (user) ->
-      callback? null, user
+    , () ->
+      callback? null
 
     , (err) ->
       callback? err

--- a/app/templates/client/components/auth(auth)/auth.service(js).js
+++ b/app/templates/client/components/auth(auth)/auth.service(js).js
@@ -84,8 +84,8 @@ angular.module('<%= scriptAppName %>')
         return User.changePassword({ id: currentUser._id }, {
           oldPassword: oldPassword,
           newPassword: newPassword
-        }, function(user) {
-          return safeCb(callback)(null, user);
+        }, function() {
+          return safeCb(callback)(null);
         }, function(err) {
           return safeCb(callback)(err);
         }).$promise;

--- a/app/templates/server/api/user(auth)/user.controller.js
+++ b/app/templates/server/api/user(auth)/user.controller.js
@@ -128,7 +128,7 @@ exports.changePassword = function(req, res, next) {
         <% if (filters.mongooseModels) { %>return user.saveAsync()<% }
            if (filters.sequelizeModels) { %>return user.save()<% } %>
           .then(function() {
-            res.status(200).end();
+            res.status(204).end();
           })
           .catch(validationError(res));
       } else {


### PR DESCRIPTION
in `app.js` there is an `event.preventDefault()` which wasn't present in the `coffee` version. I've added it.

https://github.com/DaftMonk/generator-angular-fullstack/blob/canary/app/templates/client/app/app(js).js#L52

the `auth.service#changePassword` method, shouldn't return anything on success, since the API is ending the request without any response as you can see.

https://github.com/DaftMonk/generator-angular-fullstack/blob/canary/app/templates/server/api/user(auth)/user.controller.js#L131