### PR TITLE
fix(grunt): `watch.jade` only watches jade files

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -99,10 +99,7 @@ module.exports = function (grunt) {
         tasks: ['less', 'postcss']
       },<% } if (filters.jade) { %>
       jade: {
-        files: [
-          '<%%= yeoman.client %>/{app,components}/*',
-          '<%%= yeoman.client %>/{app,components}/**/*.jade'
-        ],
+        files: ['<%%= yeoman.client %>/{app,components}/**/*.jade'],
         tasks: ['jade']
       },<% } if (filters.coffee) { %>
       coffee: {


### PR DESCRIPTION
98% of the time this does more harm than good. For those 2% you can just as easily run `grunt jade`.