### PR TITLE
feat(package): upgrade jshint packages

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -44,7 +44,7 @@
     "grunt-contrib-cssmin": "~0.9.0",
     "grunt-contrib-htmlmin": "~0.2.0",
     "grunt-contrib-imagemin": "~0.7.1",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "~0.11.2",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.1",<% if (filters.coffee) { %>
     "grunt-contrib-coffee": "^0.10.1",<% } %><% if (filters.jade) { %>
@@ -76,7 +76,7 @@
     "grunt-postcss": "^0.5.5",
     "grunt-open": "~0.2.3",
     "open": "~0.0.4",
-    "jshint-stylish": "~0.1.5",
+    "jshint-stylish": "~2.0.1",
     "connect-livereload": "^0.5.3",
     "mocha": "^2.2.5",
     "grunt-mocha-test": "~0.12.7",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt": "~0.4.1",
     "grunt-build-control": "DaftMonk/grunt-build-control",
     "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-jshint": "^0.11.2",
     "grunt-conventional-changelog": "~1.0.0",
     "grunt-env": "^0.4.1",
     "grunt-mocha-test": "^0.11.0",


### PR DESCRIPTION
Upgraded `grunt-contrib-jshint` to allow ES6 linting. It has jshint 2 as dependency. [More info](http://jshint.com/blog/2013-05-07/2-0-0/).

Also stylish being upgraded.