### PR TITLE
feat(gen): test helper `does` accepts escaped template strings

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -28,6 +28,8 @@ var AngularFullstackGenerator = yeoman.generators.Base.extend({
 
       // dynamic assertion statement
       this.does = this.is = function(foo) {
+        foo = this.engine(foo.replace(/\(;>%%<;\)/g, '<%')
+          .replace(/\(;>%<;\)/g, '%>'), this);
         if (this.filters.should) {
           return foo + '.should';
         } else {

--- a/script-base.js
+++ b/script-base.js
@@ -25,6 +25,8 @@ var Generator = module.exports = function Generator() {
 
   // dynamic assertion statement
   this.does = this.is = function(foo) {
+    foo = this.engine(foo.replace(/\(;>%%<;\)/g, '<%')
+      .replace(/\(;>%<;\)/g, '%>'), this);
     if (this.filters.should) {
       return foo + '.should';
     } else {


### PR DESCRIPTION
Changes:
* `does()` now parses yeoman style escaped template: `<%%= name %>`