### PR TITLE
feat(gen): replace `does` templating syntax

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -26,15 +26,12 @@ var AngularFullstackGenerator = yeoman.generators.Base.extend({
 
       this.filters = {};
 
-      // dynamic assertion statement
-      this.does = this.is = function(foo) {
-        foo = this.engine(foo.replace(/\(;>%%<;\)/g, '<%')
-          .replace(/\(;>%<;\)/g, '%>'), this);
-        if (this.filters.should) {
-          return foo + '.should';
-        } else {
-          return 'expect(' + foo + ').to';
-        }
+      // dynamic assertion statements
+      this.expect = function() {
+        return this.filters.expect ? 'expect(' : '';
+      }.bind(this);
+      this.to = function() {
+        return this.filters.expect ? ').to' : '.should';
       }.bind(this);
     },
 

--- a/app/templates/client/app/main/main.controller.spec(coffee).coffee
+++ b/app/templates/client/app/main/main.controller.spec(coffee).coffee
@@ -29,4 +29,4 @@ describe 'Controller: MainCtrl', ->
   it 'should attach a list of things to the scope', ->
     $httpBackend.flush()<% if (filters.jasmine) { %>
     expect(scope.awesomeThings.length).toBe 4 <% } if (filters.mocha) { %>
-    <%= does("scope.awesomeThings.length") %>.equal 4<% } %>
+    <%= expect() %>scope.awesomeThings.length<%= to() %>.equal 4<% } %>

--- a/app/templates/client/app/main/main.controller.spec(js).js
+++ b/app/templates/client/app/main/main.controller.spec(js).js
@@ -28,6 +28,6 @@ describe('Controller: MainCtrl', function() {
   it('should attach a list of things to the scope', function() {
     $httpBackend.flush();<% if (filters.jasmine) { %>
     expect(scope.awesomeThings.length).toBe(4);<% } if (filters.mocha) { %>
-    <%= does("scope.awesomeThings.length") %>.equal(4);<% } %>
+    <%= expect() %>scope.awesomeThings.length<%= to() %>.equal(4);<% } %>
   });
 });

--- a/app/templates/client/components/auth(auth)/user.service(js).js
+++ b/app/templates/client/components/auth(auth)/user.service(js).js
@@ -18,5 +18,5 @@ angular.module('<%= scriptAppName %>')
           id:'me'
         }
       }
-	  });
+    });
   });

--- a/app/templates/e2e/account(auth)/login/login.spec(mocha).js
+++ b/app/templates/e2e/account(auth)/login/login.spec(mocha).js
@@ -35,12 +35,12 @@ describe('Login View', function() {
   });
 
   it('should include login form with correct inputs and submit button', function() {
-    <%= does("page.form.email.getAttribute('type')") %>.eventually.equal('email');
-    <%= does("page.form.email.getAttribute('name')") %>.eventually.equal('email');
-    <%= does("page.form.password.getAttribute('type')") %>.eventually.equal('password');
-    <%= does("page.form.password.getAttribute('name')") %>.eventually.equal('password');
-    <%= does("page.form.submit.getAttribute('type')") %>.eventually.equal('submit');
-    <%= does("page.form.submit.getText()") %>.eventually.equal('Login');
+    <%= expect() %>page.form.email.getAttribute('type')<%= to() %>.eventually.equal('email');
+    <%= expect() %>page.form.email.getAttribute('name')<%= to() %>.eventually.equal('email');
+    <%= expect() %>page.form.password.getAttribute('type')<%= to() %>.eventually.equal('password');
+    <%= expect() %>page.form.password.getAttribute('name')<%= to() %>.eventually.equal('password');
+    <%= expect() %>page.form.submit.getAttribute('type')<%= to() %>.eventually.equal('submit');
+    <%= expect() %>page.form.submit.getText()<%= to() %>.eventually.equal('Login');
   });
 
   describe('with local auth', function() {
@@ -50,8 +50,8 @@ describe('Login View', function() {
 
       var navbar = require('../../components/navbar/navbar.po');
 
-      <%= does("browser.getCurrentUrl()") %>.eventually.equal(config.baseUrl + '/');
-      <%= does("navbar.navbarAccountGreeting.getText()") %>.eventually.equal('Hello ' + testUser.name);
+      <%= expect() %>browser.getCurrentUrl()<%= to() %>.eventually.equal(config.baseUrl + '/');
+      <%= expect() %>navbar.navbarAccountGreeting.getText()<%= to() %>.eventually.equal('Hello ' + testUser.name);
     });
 
     describe('and invalid credentials', function() {
@@ -65,10 +65,10 @@ describe('Login View', function() {
           password: 'badPassword'
         });
 
-        <%= does("browser.getCurrentUrl()") %>.eventually.equal(config.baseUrl + '/login');
+        <%= expect() %>browser.getCurrentUrl()<%= to() %>.eventually.equal(config.baseUrl + '/login');
 
         var helpBlock = page.form.element(by.css('.form-group.has-error .help-block.ng-binding'));
-        <%= does("helpBlock.getText()") %>.eventually.equal('This password is not correct.');
+        <%= expect() %>helpBlock.getText()<%= to() %>.eventually.equal('This password is not correct.');
       });
 
     });

--- a/app/templates/e2e/account(auth)/logout/logout.spec(mocha).js
+++ b/app/templates/e2e/account(auth)/logout/logout.spec(mocha).js
@@ -39,15 +39,15 @@ describe('Logout View', function() {
     it('should logout a user and redirecting to "/"', function() {
       var navbar = require('../../components/navbar/navbar.po');
 
-      <%= does("browser.getCurrentUrl()") %>.eventually.equal(config.baseUrl + '/');
-      <%= does("navbar.navbarAccountGreeting.getText()") %>.eventually.equal('Hello ' + testUser.name);
+      <%= expect() %>browser.getCurrentUrl()<%= to() %>.eventually.equal(config.baseUrl + '/');
+      <%= expect() %>navbar.navbarAccountGreeting.getText()<%= to() %>.eventually.equal('Hello ' + testUser.name);
 
       browser.get(config.baseUrl + '/logout');
 
       navbar = require('../../components/navbar/navbar.po');
 
-      <%= does("browser.getCurrentUrl()") %>.eventually.equal(config.baseUrl + '/');
-      <%= does("navbar.navbarAccountGreeting.isDisplayed()") %>.eventually.equal(false);
+      <%= expect() %>browser.getCurrentUrl()<%= to() %>.eventually.equal(config.baseUrl + '/');
+      <%= expect() %>navbar.navbarAccountGreeting.isDisplayed()<%= to() %>.eventually.equal(false);
     });
 
   });

--- a/app/templates/e2e/account(auth)/signup/signup.spec(mocha).js
+++ b/app/templates/e2e/account(auth)/signup/signup.spec(mocha).js
@@ -29,14 +29,14 @@ describe('Signup View', function() {
   });
 
   it('should include signup form with correct inputs and submit button', function() {
-    <%= does("page.form.name.getAttribute('type')") %>.eventually.equal('text');
-    <%= does("page.form.name.getAttribute('name')") %>.eventually.equal('name');
-    <%= does("page.form.email.getAttribute('type')") %>.eventually.equal('email');
-    <%= does("page.form.email.getAttribute('name')") %>.eventually.equal('email');
-    <%= does("page.form.password.getAttribute('type')") %>.eventually.equal('password');
-    <%= does("page.form.password.getAttribute('name')") %>.eventually.equal('password');
-    <%= does("page.form.submit.getAttribute('type')") %>.eventually.equal('submit');
-    <%= does("page.form.submit.getText()") %>.eventually.equal('Sign up');
+    <%= expect() %>page.form.name.getAttribute('type')<%= to() %>.eventually.equal('text');
+    <%= expect() %>page.form.name.getAttribute('name')<%= to() %>.eventually.equal('name');
+    <%= expect() %>page.form.email.getAttribute('type')<%= to() %>.eventually.equal('email');
+    <%= expect() %>page.form.email.getAttribute('name')<%= to() %>.eventually.equal('email');
+    <%= expect() %>page.form.password.getAttribute('type')<%= to() %>.eventually.equal('password');
+    <%= expect() %>page.form.password.getAttribute('name')<%= to() %>.eventually.equal('password');
+    <%= expect() %>page.form.submit.getAttribute('type')<%= to() %>.eventually.equal('submit');
+    <%= expect() %>page.form.submit.getText()<%= to() %>.eventually.equal('Sign up');
   });
 
   describe('with local auth', function() {
@@ -51,8 +51,8 @@ describe('Signup View', function() {
 
       var navbar = require('../../components/navbar/navbar.po');
 
-      <%= does("browser.getCurrentUrl()") %>.eventually.equal(config.baseUrl + '/');
-      <%= does("navbar.navbarAccountGreeting.getText()") %>.eventually.equal('Hello ' + testUser.name);
+      <%= expect() %>browser.getCurrentUrl()<%= to() %>.eventually.equal(config.baseUrl + '/');
+      <%= expect() %>navbar.navbarAccountGreeting.getText()<%= to() %>.eventually.equal('Hello ' + testUser.name);
     });
 
     describe('and invalid credentials', function() {
@@ -63,11 +63,11 @@ describe('Signup View', function() {
       it('should indicate signup failures', function() {
         page.signup(testUser);
 
-        <%= does("browser.getCurrentUrl()") %>.eventually.equal(config.baseUrl + '/signup');
-        <%= does("page.form.email.getAttribute('class')") %>.eventually.contain('ng-invalid-mongoose');
+        <%= expect() %>browser.getCurrentUrl()<%= to() %>.eventually.equal(config.baseUrl + '/signup');
+        <%= expect() %>page.form.email.getAttribute('class')<%= to() %>.eventually.contain('ng-invalid-mongoose');
 
         var helpBlock = page.form.element(by.css('.form-group.has-error .help-block.ng-binding'));
-        <%= does("helpBlock.getText()") %>.eventually.equal('The specified email address is already in use.');
+        <%= expect() %>helpBlock.getText()<%= to() %>.eventually.equal('The specified email address is already in use.');
       });
 
     });

--- a/app/templates/e2e/main/main.spec(mocha).js
+++ b/app/templates/e2e/main/main.spec(mocha).js
@@ -11,8 +11,8 @@ describe('Main View', function() {
   });
 
   it('should include jumbotron with correct data', function() {
-    <%= does("page.h1El.getText()") %>.eventually.equal('\'Allo, \'Allo!');
-    <%= does("page.imgEl.getAttribute('src')") %>.eventually.match(/yeoman.png$/);
-    <%= does("page.imgEl.getAttribute('alt')") %>.eventually.equal('I\'m Yeoman');
+    <%= expect() %>page.h1El.getText()<%= to() %>.eventually.equal('\'Allo, \'Allo!');
+    <%= expect() %>page.imgEl.getAttribute('src')<%= to() %>.eventually.match(/yeoman.png$/);
+    <%= expect() %>page.imgEl.getAttribute('alt')<%= to() %>.eventually.equal('I\'m Yeoman');
   });
 });

--- a/app/templates/server/api/user(auth)/index.spec.js
+++ b/app/templates/server/api/user(auth)/index.spec.js
@@ -41,15 +41,15 @@ var userIndex = proxyquire('./index', {
 describe('User API Router:', function() {
 
   it('should return an express router instance', function() {
-    userIndex.should.equal(routerStub);
+    <%= expect() %>userIndex<%= to() %>.equal(routerStub);
   });
 
   describe('GET /api/users', function() {
 
     it('should verify admin role and route to user.controller.index', function() {
-      routerStub.get
-                .withArgs('/', 'authService.hasRole.admin', 'userCtrl.index')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.get
+        .withArgs('/', 'authService.hasRole.admin', 'userCtrl.index')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });
@@ -57,9 +57,9 @@ describe('User API Router:', function() {
   describe('DELETE /api/users/:id', function() {
 
     it('should verify admin role and route to user.controller.destroy', function() {
-      routerStub.delete
-                .withArgs('/:id', 'authService.hasRole.admin', 'userCtrl.destroy')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.delete
+        .withArgs('/:id', 'authService.hasRole.admin', 'userCtrl.destroy')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });
@@ -67,9 +67,9 @@ describe('User API Router:', function() {
   describe('GET /api/users/me', function() {
 
     it('should be authenticated and route to user.controller.me', function() {
-      routerStub.get
-                .withArgs('/me', 'authService.isAuthenticated', 'userCtrl.me')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.get
+        .withArgs('/me', 'authService.isAuthenticated', 'userCtrl.me')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });
@@ -77,9 +77,9 @@ describe('User API Router:', function() {
   describe('PUT /api/users/:id/password', function() {
 
     it('should be authenticated and route to user.controller.changePassword', function() {
-      routerStub.put
-                .withArgs('/:id/password', 'authService.isAuthenticated', 'userCtrl.changePassword')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.put
+        .withArgs('/:id/password', 'authService.isAuthenticated', 'userCtrl.changePassword')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });
@@ -87,9 +87,9 @@ describe('User API Router:', function() {
   describe('GET /api/users/:id', function() {
 
     it('should be authenticated and route to user.controller.show', function() {
-      routerStub.get
-                .withArgs('/:id', 'authService.isAuthenticated', 'userCtrl.show')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.get
+        .withArgs('/:id', 'authService.isAuthenticated', 'userCtrl.show')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });
@@ -97,9 +97,9 @@ describe('User API Router:', function() {
   describe('POST /api/users', function() {
 
     it('should route to user.controller.create', function() {
-      routerStub.post
-                .withArgs('/', 'userCtrl.create')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.post
+        .withArgs('/', 'userCtrl.create')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });

--- a/app/templates/server/api/user(auth)/user.integration.js
+++ b/app/templates/server/api/user(auth)/user.integration.js
@@ -55,7 +55,7 @@ describe('User API:', function() {
         .expect(200)
         .expect('Content-Type', /json/)
         .end(function(err, res) {
-          res.body._id.toString().should.equal(user._id.toString());
+          <%= expect() %>res.body._id.toString()<%= to() %>.equal(user._id.toString());
           done();
         });
     });

--- a/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
@@ -28,22 +28,22 @@ describe('User Model', function() {
   });
 
   it('should begin with no users', function() {
-    return User.findAsync({})
-      .should.eventually.have.length(0);
+    return <%= expect() %>User.findAsync({})<%= to() %>
+      .eventually.have.length(0);
   });
 
   it('should fail when saving a duplicate user', function() {
-    return user.saveAsync()
+    return <%= expect() %>user.saveAsync()
       .then(function() {
         var userDup = genUser();
         return userDup.saveAsync();
-      }).should.be.rejected;
+      })<%= to() %>.be.rejected;
   });
 
   describe('#email', function() {
     it('should fail when saving without an email', function() {
       user.email = '';
-      return user.saveAsync().should.be.rejected;
+      return <%= expect() %>user.saveAsync()<%= to() %>.be.rejected;
     });
   });
 
@@ -53,19 +53,19 @@ describe('User Model', function() {
     });
 
     it('should authenticate user if valid', function() {
-      user.authenticate('password').should.be.true;
+      <%= expect() %>user.authenticate('password')<%= to() %>.be.true;
     });
 
     it('should not authenticate user if invalid', function() {
-      user.authenticate('blah').should.not.be.true;
+      <%= expect() %>user.authenticate('blah')<%= to() %>.not.be.true;
     });
 
     it('should remain the same hash unless the password is updated', function() {
       user.name = 'Test User';
-      return user.saveAsync()
+      return <%= expect() %>user.saveAsync()
         .spread(function(u) {
           return u.authenticate('password');
-        }).should.eventually.be.true;
+        })<%= to() %>.eventually.be.true;
     });
   });
 

--- a/app/templates/server/api/user(auth)/user.model.spec(sequelizeModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(sequelizeModels).js
@@ -30,22 +30,22 @@ describe('User Model', function() {
   });
 
   it('should begin with no users', function() {
-    return User.findAll()
-      .should.eventually.have.length(0);
+    return <%= expect() %>User.findAll()<%= to() %>
+      .eventually.have.length(0);
   });
 
   it('should fail when saving a duplicate user', function() {
-    return user.save()
+    return <%= expect() %>user.save()
       .then(function() {
         var userDup = genUser();
         return userDup.save();
-      }).should.be.rejected;
+      })<%= to() %>.be.rejected;
   });
 
   describe('#email', function() {
     it('should fail when saving without an email', function() {
       user.email = '';
-      return user.save().should.be.rejected;
+      return <%= expect() %>user.save()<%= to() %>.be.rejected;
     });
   });
 
@@ -55,19 +55,19 @@ describe('User Model', function() {
     });
 
     it('should authenticate user if valid', function() {
-      user.authenticate('password').should.be.true;
+      <%= expect() %>user.authenticate('password')<%= to() %>.be.true;
     });
 
     it('should not authenticate user if invalid', function() {
-      user.authenticate('blah').should.not.be.true;
+      <%= expect() %>user.authenticate('blah')<%= to() %>.not.be.true;
     });
 
     it('should remain the same hash unless the password is updated', function() {
       user.name = 'Test User';
-      return user.save()
+      return <%= expect() %>user.save()
         .then(function(u) {
           return u.authenticate('password');
-        }).should.eventually.be.true;
+        })<%= to() %>.eventually.be.true;
     });
   });
 

--- a/endpoint/templates/basename.integration.js
+++ b/endpoint/templates/basename.integration.js
@@ -25,7 +25,7 @@ describe('<%= classedName %> API:', function() {
     });
 
     it('should respond with JSON array', function() {
-      <%= cameledName %>s.should.be.instanceOf(Array);
+      <%= expect() %><%= cameledName %>s<%= to() %>.be.instanceOf(Array);
     });
 
   });<% if(filters.models) { %>
@@ -50,8 +50,8 @@ describe('<%= classedName %> API:', function() {
     });
 
     it('should respond with the newly created <%= cameledName %>', function() {
-      new<%= classedName %>.name.should.equal('New <%= classedName %>');
-      new<%= classedName %>.info.should.equal('This is the brand new <%= cameledName %>!!!');
+      <%= expect() %>new<%= classedName %>.name<%= to() %>.equal('New <%= classedName %>');
+      <%= expect() %>new<%= classedName %>.info<%= to() %>.equal('This is the brand new <%= cameledName %>!!!');
     });
 
   });
@@ -78,8 +78,8 @@ describe('<%= classedName %> API:', function() {
     });
 
     it('should respond with the requested <%= cameledName %>', function() {
-      <%= cameledName %>.name.should.equal('New <%= classedName %>');
-      <%= cameledName %>.info.should.equal('This is the brand new <%= cameledName %>!!!');
+      <%= expect() %><%= cameledName %>.name<%= to() %>.equal('New <%= classedName %>');
+      <%= expect() %><%= cameledName %>.info<%= to() %>.equal('This is the brand new <%= cameledName %>!!!');
     });
 
   });
@@ -110,8 +110,8 @@ describe('<%= classedName %> API:', function() {
     });
 
     it('should respond with the updated <%= cameledName %>', function() {
-      updated<%= classedName %>.name.should.equal('Updated <%= classedName %>');
-      updated<%= classedName %>.info.should.equal('This is the updated <%= cameledName %>!!!');
+      <%= expect() %>updated<%= classedName %>.name<%= to() %>.equal('Updated <%= classedName %>');
+      <%= expect() %>updated<%= classedName %>.info<%= to() %>.equal('This is the updated <%= cameledName %>!!!');
     });
 
   });

--- a/endpoint/templates/index.spec.js
+++ b/endpoint/templates/index.spec.js
@@ -31,15 +31,15 @@ var <%= cameledName %>Index = proxyquire('./index.js', {
 describe('<%= classedName %> API Router:', function() {
 
   it('should return an express router instance', function() {
-    <%= cameledName %>Index.should.equal(routerStub);
+    <%= expect() %><%= cameledName %>Index<%= to() %>.equal(routerStub);
   });
 
   describe('GET <%= route %>', function() {
 
     it('should route to <%= cameledName %>.controller.index', function() {
-      routerStub.get
-                .withArgs('/', '<%= cameledName %>Ctrl.index')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.get
+        .withArgs('/', '<%= cameledName %>Ctrl.index')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });<% if(filters.models) { %>
@@ -47,9 +47,9 @@ describe('<%= classedName %> API Router:', function() {
   describe('GET <%= route %>/:id', function() {
 
     it('should route to <%= cameledName %>.controller.show', function() {
-      routerStub.get
-                .withArgs('/:id', '<%= cameledName %>Ctrl.show')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.get
+        .withArgs('/:id', '<%= cameledName %>Ctrl.show')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });
@@ -57,9 +57,9 @@ describe('<%= classedName %> API Router:', function() {
   describe('POST <%= route %>', function() {
 
     it('should route to <%= cameledName %>.controller.create', function() {
-      routerStub.post
-                .withArgs('/', '<%= cameledName %>Ctrl.create')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.post
+        .withArgs('/', '<%= cameledName %>Ctrl.create')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });
@@ -67,9 +67,9 @@ describe('<%= classedName %> API Router:', function() {
   describe('PUT <%= route %>/:id', function() {
 
     it('should route to <%= cameledName %>.controller.update', function() {
-      routerStub.put
-                .withArgs('/:id', '<%= cameledName %>Ctrl.update')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.put
+        .withArgs('/:id', '<%= cameledName %>Ctrl.update')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });
@@ -77,9 +77,9 @@ describe('<%= classedName %> API Router:', function() {
   describe('PATCH <%= route %>/:id', function() {
 
     it('should route to <%= cameledName %>.controller.update', function() {
-      routerStub.patch
-                .withArgs('/:id', '<%= cameledName %>Ctrl.update')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.patch
+        .withArgs('/:id', '<%= cameledName %>Ctrl.update')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });
@@ -87,9 +87,9 @@ describe('<%= classedName %> API Router:', function() {
   describe('DELETE <%= route %>/:id', function() {
 
     it('should route to <%= cameledName %>.controller.destroy', function() {
-      routerStub.delete
-                .withArgs('/:id', '<%= cameledName %>Ctrl.destroy')
-                .should.have.been.calledOnce;
+      <%= expect() %>routerStub.delete
+        .withArgs('/:id', '<%= cameledName %>Ctrl.destroy')
+        <%= to() %>.have.been.calledOnce;
     });
 
   });<% } %>

--- a/script-base.js
+++ b/script-base.js
@@ -23,15 +23,12 @@ var Generator = module.exports = function Generator() {
   this.basename = path.basename(this.name);
   this.dirname = (this.name.indexOf('/') >= 0) ? path.dirname(this.name) : this.name;
 
-  // dynamic assertion statement
-  this.does = this.is = function(foo) {
-    foo = this.engine(foo.replace(/\(;>%%<;\)/g, '<%')
-      .replace(/\(;>%<;\)/g, '%>'), this);
-    if (this.filters.should) {
-      return foo + '.should';
-    } else {
-      return 'expect(' + foo + ').to';
-    }
+  // dynamic assertion statements
+  this.expect = function() {
+    return this.filters.expect ? 'expect(' : '';
+  }.bind(this);
+  this.to = function() {
+    return this.filters.expect ? ').to' : '.should';
   }.bind(this);
 
   // dynamic relative require path


### PR DESCRIPTION
Changes:
* Use `<%= expect() %>ASSERTION_SUBJECT<%= to() %>` syntax
* Implement dynamic assertions for all server tests including endpoints
* Default to `should` even when jasmine is chosen since there are no
jasmine server tests
* Refactor tests to comply with project indentation

closes DaftMonk/generator-angular-fullstack#1163