### PR TITLE
Feature: promisify mongoose directly

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -17,7 +17,7 @@
     "jade": "~1.2.0",<% } %><% if (filters.html) { %>
     "ejs": "~0.8.4",<% } %><% if (filters.mongoose) { %>
     "mongoose": "^4.1.2",
-    "mongoose-bird": "~0.0.1",
+    "bluebird": "^2.9.34",
     "connect-mongo": "^0.8.1",<% } %><% if (filters.sequelize) { %>
     "sequelize": "^3.5.1",
     "sqlite3": "~3.0.2",<% } %><% if (filters.auth) { %>

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,7 +16,7 @@
     "babel-core": "^5.6.4",<% if (filters.jade) { %>
     "jade": "~1.2.0",<% } %><% if (filters.html) { %>
     "ejs": "~0.8.4",<% } %><% if (filters.mongoose) { %>
-    "mongoose": "~4.0.3",
+    "mongoose": "^4.1.2",
     "mongoose-bird": "~0.0.1",
     "connect-mongo": "^0.8.1",<% } %><% if (filters.sequelize) { %>
     "sequelize": "^3.5.1",

--- a/app/templates/protractor.conf.js
+++ b/app/templates/protractor.conf.js
@@ -82,7 +82,7 @@ var config = {
     var serverConfig = config.params.serverConfig;<% if (filters.mongoose) { %>
 
     // Setup mongo for tests
-    var mongoose = require('mongoose-bird')();
+    var mongoose = require('mongoose');
     mongoose.connect(serverConfig.mongo.uri, serverConfig.mongo.options); // Connect to database<% } %>
   }
 };

--- a/app/templates/server/api/user(auth)/user.model(mongooseModels).js
+++ b/app/templates/server/api/user(auth)/user.model(mongooseModels).js
@@ -1,6 +1,6 @@
 'use strict';
 
-var mongoose = require('mongoose-bird')();
+var mongoose = require('bluebird').promisifyAll(require('mongoose'));
 var Schema = mongoose.Schema;
 var crypto = require('crypto');<% if (filters.oauth) { %>
 var authTypes = ['github', 'twitter', 'facebook', 'google'];<% } %>

--- a/app/templates/server/app.js
+++ b/app/templates/server/app.js
@@ -8,7 +8,7 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 var express = require('express');<% if (filters.mongoose) { %>
-var mongoose = require('mongoose-bird')();<% } %><% if (filters.sequelize) { %>
+var mongoose = require('mongoose');<% } %><% if (filters.sequelize) { %>
 var sqldb = require('./sqldb');<% } %>
 var config = require('./config/environment');
 <% if (filters.mongoose) { %>

--- a/app/templates/server/auth(auth)/auth.service.js
+++ b/app/templates/server/auth(auth)/auth.service.js
@@ -1,6 +1,5 @@
 'use strict';
-<% if (filters.mongooseModels) { %>
-var mongoose = require('mongoose-bird')();<% } %>
+
 var passport = require('passport');
 var config = require('../config/environment');
 var jwt = require('jsonwebtoken');

--- a/app/templates/server/config/express.js
+++ b/app/templates/server/config/express.js
@@ -17,7 +17,7 @@ var config = require('./environment');<% if (filters.auth) { %>
 var passport = require('passport');<% } %><% if (filters.twitterAuth) { %>
 var session = require('express-session');<% if (filters.mongoose) { %>
 var mongoStore = require('connect-mongo')(session);
-var mongoose = require('mongoose-bird')();<% } %><% } %>
+var mongoose = require('mongoose');<% } %><% } %>
 
 module.exports = function(app) {
   var env = app.get('env');

--- a/endpoint/templates/basename.model(mongooseModels).js
+++ b/endpoint/templates/basename.model(mongooseModels).js
@@ -1,6 +1,6 @@
 'use strict';
 
-var mongoose = require('mongoose-bird')();
+var mongoose = require('bluebird').promisifyAll(require('mongoose'));
 var Schema = mongoose.Schema;
 
 var <%= classedName %>Schema = new Schema({


### PR DESCRIPTION
Changes:
* Remove `mongoose-bird` dependency
* Add `bluebird` dependency
* Use `bluebird.promisifyAll` when requiring `mongoose` for models
* update mongoose to `^4.1.2`