### PR TITLE
refactor(data): Change seed user account emails to example.com

### DIFF
--- a/app/templates/client/app/account(auth)/login/login(html).html
+++ b/app/templates/client/app/account(auth)/login/login(html).html
@@ -4,8 +4,8 @@
   <div class="row">
     <div class="col-sm-12">
       <h1>Login</h1>
-      <p>Accounts are reset on server restart from <code>server/config/seed.js</code>. Default account is <code>test@test.com</code> / <code>test</code></p>
-      <p>Admin account is <code>admin@admin.com</code> / <code>admin</code></p>
+      <p>Accounts are reset on server restart from <code>server/config/seed.js</code>. Default account is <code>test@example.com</code> / <code>test</code></p>
+      <p>Admin account is <code>admin@example.com</code> / <code>admin</code></p>
     </div>
     <div class="col-sm-12">
       <form class="form" name="form" ng-submit="login(form)" novalidate>

--- a/app/templates/client/app/account(auth)/login/login(jade).jade
+++ b/app/templates/client/app/account(auth)/login/login(jade).jade
@@ -7,12 +7,12 @@ navbar
         | Accounts are reset on server restart from
         code server/config/seed.js
         | . Default account is
-        code test@test.com
+        code test@example.com
         | /
         code test
       p
         | Admin account is
-        code admin@admin.com
+        code admin@example.com
         | /
         code admin
 

--- a/app/templates/e2e/account(auth)/login/login.spec(jasmine).js
+++ b/app/templates/e2e/account(auth)/login/login.spec(jasmine).js
@@ -14,7 +14,7 @@ describe('Login View', function() {
 
   var testUser = {
     name: 'Test User',
-    email: 'test@test.com',
+    email: 'test@example.com',
     password: 'test'
   };
 

--- a/app/templates/e2e/account(auth)/login/login.spec(mocha).js
+++ b/app/templates/e2e/account(auth)/login/login.spec(mocha).js
@@ -14,7 +14,7 @@ describe('Login View', function() {
 
   var testUser = {
     name: 'Test User',
-    email: 'test@test.com',
+    email: 'test@example.com',
     password: 'test'
   };
 

--- a/app/templates/e2e/account(auth)/logout/logout.spec(jasmine).js
+++ b/app/templates/e2e/account(auth)/logout/logout.spec(jasmine).js
@@ -12,7 +12,7 @@ describe('Logout View', function() {
 
   var testUser = {
     name: 'Test User',
-    email: 'test@test.com',
+    email: 'test@example.com',
     password: 'test'
   };
 

--- a/app/templates/e2e/account(auth)/logout/logout.spec(mocha).js
+++ b/app/templates/e2e/account(auth)/logout/logout.spec(mocha).js
@@ -12,7 +12,7 @@ describe('Logout View', function() {
 
   var testUser = {
     name: 'Test User',
-    email: 'test@test.com',
+    email: 'test@example.com',
     password: 'test'
   };
 

--- a/app/templates/e2e/account(auth)/signup/signup.spec(jasmine).js
+++ b/app/templates/e2e/account(auth)/signup/signup.spec(jasmine).js
@@ -15,7 +15,7 @@ describe('Signup View', function() {
 
   var testUser = {
     name: 'Test',
-    email: 'test@test.com',
+    email: 'test@example.com',
     password: 'test'
   };
 

--- a/app/templates/e2e/account(auth)/signup/signup.spec(mocha).js
+++ b/app/templates/e2e/account(auth)/signup/signup.spec(mocha).js
@@ -15,7 +15,7 @@ describe('Signup View', function() {
 
   var testUser = {
     name: 'Test',
-    email: 'test@test.com',
+    email: 'test@example.com',
     password: 'test'
   };
 

--- a/app/templates/server/api/user(auth)/user.integration.js
+++ b/app/templates/server/api/user(auth)/user.integration.js
@@ -15,7 +15,7 @@ describe('User API:', function() {
       <% if (filters.mongooseModels) { %>user = new User({<% }
          if (filters.sequelizeModels) { %>user = User.build({<% } %>
         name: 'Fake User',
-        email: 'test@test.com',
+        email: 'test@example.com',
         password: 'password'
       });
 
@@ -37,7 +37,7 @@ describe('User API:', function() {
       request(app)
         .post('/auth/local')
         .send({
-          email: 'test@test.com',
+          email: 'test@example.com',
           password: 'password'
         })
         .expect(200)

--- a/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(mongooseModels).js
@@ -7,7 +7,7 @@ var genUser = function() {
   user = new User({
     provider: 'local',
     name: 'Fake User',
-    email: 'test@test.com',
+    email: 'test@example.com',
     password: 'password'
   });
   return user;

--- a/app/templates/server/api/user(auth)/user.model.spec(sequelizeModels).js
+++ b/app/templates/server/api/user(auth)/user.model.spec(sequelizeModels).js
@@ -7,7 +7,7 @@ var genUser = function() {
   user = User.build({
     provider: 'local',
     name: 'Fake User',
-    email: 'test@test.com',
+    email: 'test@example.com',
     password: 'password'
   });
   return user;

--- a/app/templates/server/config/seed(models).js
+++ b/app/templates/server/config/seed(models).js
@@ -60,13 +60,13 @@ var Thing = sqldb.Thing;
        if (filters.sequelizeModels) { %>User.bulkCreate([{<% } %>
       provider: 'local',
       name: 'Test User',
-      email: 'test@test.com',
+      email: 'test@example.com',
       password: 'test'
     }, {
       provider: 'local',
       role: 'admin',
       name: 'Admin',
-      email: 'admin@admin.com',
+      email: 'admin@example.com',
       password: 'admin'
     <% if (filters.mongooseModels) { %>})<% }
        if (filters.sequelizeModels) { %>}])<% } %>


### PR DESCRIPTION
Privately registered domain names such as admin.com should not
be used in seed or test data. Change the email address of the
'test' and 'admin' user accounts to 'test@example.com' and
'admin@example.com' respectively.