### PR TITLE
Fix bootstrap.js always excluded

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -249,7 +249,7 @@ module.exports = function (grunt) {
     wiredep: {
       options: {
         exclude: [
-          /bootstrap.js/,
+          <% if(filters.uibootstrap) { %>/bootstrap.js/,<% } %>
           '/json3/',
           '/es5-shim/'<% if(!filters.css) { %>,
           /font-awesome\.css/<% if(filters.bootstrap) { %>,

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -248,8 +248,8 @@ module.exports = function (grunt) {
     // Automatically inject Bower components into the app and karma.conf.js
     wiredep: {
       options: {
-        exclude: [
-          <% if(filters.uibootstrap) { %>/bootstrap.js/,<% } %>
+        exclude: [ <% if(filters.uibootstrap) { %>
+          /bootstrap.js/,<% } %>
           '/json3/',
           '/es5-shim/'<% if(!filters.css) { %>,
           /font-awesome\.css/<% if(filters.bootstrap) { %>,


### PR DESCRIPTION
Added test for `filters.uibootstrap === true` to exclude `bootstrap.js`.

Fixes #565 