### PR TITLE
feat(gen): ignore angular-fullstack-deps and test for npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+angular-fullstack-deps
+test


### PR DESCRIPTION
This will reduce the published size quite a bit since `test/fixtures` was previously being published

[ci skip]