### PR TITLE
chore(travis): add node 4.0.0 to travis targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,15 @@ sudo: false
 language: node_js
 node_js:
   - '0.12'
+  - '4.0.0'
 env:
   global:
     - SAUCE_USERNAME=fullstack_ci
     - SAUCE_ACCESS_KEY=1a527ca6-4aa5-4618-86ce-0278bf158cbf
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: 4.0.0
 before_install:
   - ./scripts/sauce_connect_setup.sh
   - gem update --system

--- a/app/templates/.travis.yml
+++ b/app/templates/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
   - '0.12'
+  - '4.0.0'
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: 4.0.0
 before_script:
   - npm install -g bower grunt-cli<% if (filters.sass) { %>
   - gem install sass<% } %>


### PR DESCRIPTION
We'll allow failures on node 4.0.0 for now. If we start seeing node 4.0.0 passing in travis, we can remove the `allow_failures`.