### PR TITLE
Error handling for email not provided

### DIFF
--- a/app/templates/server/auth(auth)/facebook(facebookAuth)/passport.js
+++ b/app/templates/server/auth(auth)/facebook(facebookAuth)/passport.js
@@ -17,11 +17,17 @@ exports.setup = function(User, config) {
       'facebook.id': profile.id
     })
       .then(function(user) {
+        var email;
         if (!user) {
+          if(typeof profile.emails == undefined) {
+            email = "";
+          } else {
+            email = profile.emails[0].value
+          }
           <% if (filters.mongooseModels) { %>user = new User({<% }
              if (filters.sequelizeModels) { %>user = User.build({<% } %>
             name: profile.displayName,
-            email: profile.emails[0].value,
+            email: email,
             role: 'user',
             provider: 'facebook',
             facebook: profile._json


### PR DESCRIPTION
Many times, Facebook users will not allow the app to get the email. If they do this, the app will literally crash and they will see just a white screen with nowhere else to go. This change will let the app check wether the email field was provided, and if it wasn't, it'll just make an empty string of it. Would anyone else suggest a different datatype?