### PR TITLE
fix(auth.service.js): Replaces deprecated expiresInMinutes 

### DIFF
--- a/app/templates/server/auth(auth)/auth.service.js
+++ b/app/templates/server/auth(auth)/auth.service.js
@@ -72,7 +72,7 @@ function hasRole(roleRequired) {
  */
 function signToken(id, role) {
   return jwt.sign({ _id: id, role: role }, config.secrets.session, {
-    expiresInMinutes: 60 * 5
+    expiresIn: "5h"
   });
 }
 


### PR DESCRIPTION
expiresIn can be expressed in seconds or a string describing a time span. Eg: 60, "2 days", "10h", "7d"