### PR TITLE
fix(app): change saveAsync chain from 'then' to 'spread'.

### DIFF
--- a/app/templates/server/auth(auth)/facebook(facebookAuth)/passport.js
+++ b/app/templates/server/auth(auth)/facebook(facebookAuth)/passport.js
@@ -26,9 +26,8 @@ exports.setup = function(User, config) {
             provider: 'facebook',
             facebook: profile._json
           });
-          <% if (filters.mongooseModels) { %>user.saveAsync()<% }
-             if (filters.sequelizeModels) { %>user.save()<% } %>
-            .then(function(user) {
+          <% if (filters.mongooseModels) { %>user.saveAsync().spread(function(user) {<% }
+             if (filters.sequelizeModels) { %>user.save().then(function(user) {<% } %>
               return done(null, user);
             })
             .catch(function(err) {

--- a/app/templates/server/auth(auth)/google(googleAuth)/passport.js
+++ b/app/templates/server/auth(auth)/google(googleAuth)/passport.js
@@ -23,9 +23,8 @@ exports.setup = function(User, config) {
             provider: 'google',
             google: profile._json
           });
-          <% if (filters.mongooseModels) { %>user.saveAsync()<% }
-             if (filters.sequelizeModels) { %>user.save()<% } %>
-            .then(function(user) {
+          <% if (filters.mongooseModels) { %>user.saveAsync().spread(function(user) {<% }
+             if (filters.sequelizeModels) { %>user.save().then(function(user) {<% } %>
               return done(null, user);
             })
             .catch(function(err) {

--- a/app/templates/server/auth(auth)/twitter(twitterAuth)/passport.js
+++ b/app/templates/server/auth(auth)/twitter(twitterAuth)/passport.js
@@ -22,9 +22,8 @@ exports.setup = function(User, config) {
             provider: 'twitter',
             twitter: profile._json
           });
-          <% if (filters.mongooseModels) { %>user.saveAsync()<% }
-             if (filters.sequelizeModels) { %>user.save()<% } %>
-            .then(function(user) {
+          <% if (filters.mongooseModels) { %>user.saveAsync().spread(function(user) {<% }
+             if (filters.sequelizeModels) { %>user.save().then(function(user) {<% } %>
               return done(null, user);
             })
             .catch(function(err) {


### PR DESCRIPTION
On mongoose 4.x, model.save()'s callback function have two arguments:
object and numberAffected. So, on passport.js, we need to use "spread"
instead of "then" to accept those arguments.