### PR TITLE
fix(app): remove needless and harmful DOMAIN setting

### DIFF
--- a/app/templates/server/config/_local.env.js
+++ b/app/templates/server/config/_local.env.js
@@ -6,7 +6,6 @@
 // You will need to set these on the server you deploy to.
 
 module.exports = {
-  DOMAIN: 'http://localhost:9000',
   SESSION_SECRET: '<%= lodash.slugify(appname) + "-secret" %>',<% if (filters.facebookAuth) { %>
 
   FACEBOOK_ID: 'app-id',

--- a/app/templates/server/config/_local.env.sample.js
+++ b/app/templates/server/config/_local.env.sample.js
@@ -6,7 +6,6 @@
 // You will need to set these on the server you deploy to.
 
 module.exports = {
-  DOMAIN:           'http://localhost:9000',
   SESSION_SECRET:   '<%= lodash.slugify(appname) + "-secret" %>',<% if (filters.facebookAuth) { %>
 
   FACEBOOK_ID:      'app-id',


### PR DESCRIPTION
Oauth fails if DOMAIN environment variable exists and a browser connect
to the server from remote host to use different browser/OS.