### PR TITLE
Update _package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -45,7 +45,7 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-cssmin": "^0.14.0",
-    "grunt-contrib-imagemin": "^0.9.4",
+    "grunt-contrib-imagemin": "~1.0.0",
     "grunt-contrib-jshint": "~0.11.2",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "~0.6.1",<% if (filters.jade) { %>


### PR DESCRIPTION
Update `grunt-contrib-imagemin` version in order to fix the error when using `npm install` with Node v4.2.2, #1412. 