### PR TITLE
Jason Web Token api update (deprecation warning)

### DIFF
--- a/app/templates/server/auth(auth)/auth.service.js
+++ b/app/templates/server/auth(auth)/auth.service.js
@@ -72,7 +72,7 @@ function hasRole(roleRequired) {
  */
 function signToken(id, role) {
   return jwt.sign({ _id: id, role: role }, config.secrets.session, {
-    expiresInMinutes: 60 * 5
+    expiresIn: 60 * 60 * 5
   });
 }
 


### PR DESCRIPTION
jsonwebtoken: expiresInMinutes and expiresInSeconds is deprecated. Using expiresIn (suggested - which is in seconds) and changing the token 'expiresIn' value to 60 * 60 * 5 (previously expressed in minutes, now expressed in seconds).